### PR TITLE
NGINX config update for /api location

### DIFF
--- a/conf/nginx-testing.conf
+++ b/conf/nginx-testing.conf
@@ -57,41 +57,11 @@ server {
         }
 
         location /api {
-            if ($request_method = 'GET') {
-               add_header 'Access-Control-Allow-Origin' '*';
-               add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS';
-               add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range, access-control-allow-origin';
-               add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
-            }
-
-            if ($request_method = 'PUT') {
-               add_header 'Access-Control-Allow-Origin' '*';
-               add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS';
-               add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range, access-control-allow-origin';
-               add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
-            }
-
-            if ($request_method = 'POST') {
-               add_header 'Access-Control-Allow-Origin' '*';
-               add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS';
-               add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range, access-control-allow-origin';
-               add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
-            }
-
-
-            if ($request_method = 'DELETE') {
-               add_header 'Access-Control-Allow-Origin' '*';
-               add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS';
-               add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range, access-control-allow-origin';
-               add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
-            }
-
             if ($request_method = 'OPTIONS') {
-               add_header 'Access-Control-Allow-Origin' '*';
                add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS';
-               add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range, Access-Control-Allow-Origin';
-               add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
             }
+            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+            add_header 'Access-Control-Allow-Headers' 'DNT, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Range, X-Auth, Accept, Origin';
             include proxy_params;
             proxy_pass http://unix:/var/run/yang/yang-catalog.sock ;
             proxy_read_timeout 600s;

--- a/conf/yangcatalog-nginx-ssl.conf
+++ b/conf/yangcatalog-nginx-ssl.conf
@@ -56,41 +56,11 @@ server {
         }
 
         location /api {
-            if ($request_method = 'GET') {
-               add_header 'Access-Control-Allow-Origin' '*';
-               add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS';
-               add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range, access-control-allow-origin';
-               add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
-            }
-
-            if ($request_method = 'PUT') {
-               add_header 'Access-Control-Allow-Origin' '*';
-               add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS';
-               add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range, access-control-allow-origin';
-               add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
-            }
-
-            if ($request_method = 'POST') {
-               add_header 'Access-Control-Allow-Origin' '*';
-               add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS';
-               add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range, access-control-allow-origin';
-               add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
-            }
-
-
-            if ($request_method = 'DELETE') {
-               add_header 'Access-Control-Allow-Origin' '*';
-               add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS';
-               add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range, access-control-allow-origin';
-               add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
-            }
-
             if ($request_method = 'OPTIONS') {
-               add_header 'Access-Control-Allow-Origin' '*';
                add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS';
-               add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range, Access-Control-Allow-Origin';
-               add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
             }
+            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+            add_header 'Access-Control-Allow-Headers' 'DNT, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Range, X-Auth, Accept, Origin';
             include proxy_params;
             proxy_pass http://unix:/var/run/yang/yang-catalog.sock ;
             proxy_read_timeout 600s;


### PR DESCRIPTION
- Access-Control-Allow-Headers list extended by values from backend functionality
- Access-Control-Allow-Methods only provided for OPTIONS (pre-flight)

This resolves #42 
Signed-off-by: Slavomir Mazur <slavomir.mazur@pantheon.tech>