### PR TITLE
Fix: missing env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,8 @@ services:
   api-receiver:
     container_name: yc-api-receiver
     image: catalog_backend_api:latest
+    environment:
+      YANGCATALOG_CONFIG_PATH: ${YANGCATALOG_CONFIG_PATH}
     command: bash -c "chown -R yang:yang /var/run/yang; service postfix start; su yang; python api/receiver.py"
     volumes:
       - ${YANG_RESOURCES}/conf/yangcatalog.conf:/etc/yangcatalog/yangcatalog.conf:ro
@@ -101,6 +103,8 @@ services:
   api-recovery:
     container_name: yc-api-recovery
     image: catalog_backend_api:latest
+    environment:
+      YANGCATALOG_CONFIG_PATH: ${YANGCATALOG_CONFIG_PATH}
     command: bash -c "source bin/activate; python recovery/recovery.py --type load --protocol http --ip yc-confd"
     volumes:
       - ${YANG_RESOURCES}/conf/yangcatalog.conf:/etc/yangcatalog/yangcatalog.conf:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
         - YANG_ID=${YANG_ID}
         - YANG_GID=${YANG_GID}
         - CRON_MAIL_TO=${CRON_MAIL_TO}
+        - YANGCATALOG_CONFIG_PATH=${YANGCATALOG_CONFIG_PATH}
     volumes:
       - ${YANG_RESOURCES}/conf/yangcatalog.conf:/etc/yangcatalog/yangcatalog.conf:rw
       - ${YANG_RESOURCES}:/var/yang:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,6 @@ services:
   backend:
     container_name: yc-backend
     image: catalog_backend_api:latest
-    environment:
-      YANGCATALOG_CONFIG_PATH: ${YANGCATALOG_CONFIG_PATH}
     build:
       context: .
       dockerfile: ./backend/Dockerfile
@@ -81,8 +79,6 @@ services:
   api-receiver:
     container_name: yc-api-receiver
     image: catalog_backend_api:latest
-    environment:
-      YANGCATALOG_CONFIG_PATH: ${YANGCATALOG_CONFIG_PATH}
     command: bash -c "chown -R yang:yang /var/run/yang; service postfix start; su yang; python api/receiver.py"
     volumes:
       - ${YANG_RESOURCES}/conf/yangcatalog.conf:/etc/yangcatalog/yangcatalog.conf:ro
@@ -104,8 +100,6 @@ services:
   api-recovery:
     container_name: yc-api-recovery
     image: catalog_backend_api:latest
-    environment:
-      YANGCATALOG_CONFIG_PATH: ${YANGCATALOG_CONFIG_PATH}
     command: bash -c "source bin/activate; python recovery/recovery.py --type load --protocol http --ip yc-confd"
     volumes:
       - ${YANG_RESOURCES}/conf/yangcatalog.conf:/etc/yangcatalog/yangcatalog.conf:ro


### PR DESCRIPTION
yangcatalog config path was missing for yc-api-receiver and yc-api-recovery