### PR TITLE
NGINX: Redirect yangvalidator.com directly to yangvalidator page

### DIFF
--- a/conf/nginx-testing.conf
+++ b/conf/nginx-testing.conf
@@ -1,9 +1,9 @@
 server {
     listen 80;
-    server_name  localhost;
+    server_name localhost;
 
-    access_log  /var/log/nginx/access.log  ;
-    error_log  /var/log/nginx/error.log  ;
+    access_log /var/log/nginx/access.log ;
+    error_log /var/log/nginx/error.log ;
 
     charset utf-8;
 
@@ -13,101 +13,102 @@ server {
     rewrite_log on ;
 
     location / {
-        root   /usr/share/nginx/html;
+        root /usr/share/nginx/html;
         try_files $uri $uri/ /index.html =404;
-    # Allows for server side includes
-    ssi on;
-    ssi_last_modified on;
+        # Allows for server side includes
+        ssi on;
+        ssi_last_modified on;
     }
 
     location /error/ {
         # Allows for server side includes
-        ssi on ;
-        ssi_last_modified on ;
-        root /usr/share/nginx/html ;
+        ssi on;
+        ssi_last_modified on;
+        root /usr/share/nginx/html;
         internal ;
     }
 
-#
-# Redirect for previously well-known URI processed by PHP
-#
-        location = /contribute.php {
-                return 301 http://$host/contribute.html ;
+    #
+    # Redirect for previously well-known URI processed by PHP
+    #
+    location = /contribute.php {
+        return 301 http://$host/contribute.html ;
+    }
+
+    #
+    # Admin GUI
+    #
+    location = /admin {
+        return 301 http://$host/api/admin/login;
+    }
+
+    location /admin/ {
+        alias /usr/share/nginx/html/admin/;
+        try_files $uri $uri/ /index.html =404;
+    }
+
+    #
+    # API
+    #
+    location /doc {
+        alias /usr/share/nginx/html/slate/build;
+    }
+
+    location = /admin/login {
+        return 301 http://$host/api/admin/login;
+    }
+
+    location /api {
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS';
+        }
+        add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+        add_header 'Access-Control-Allow-Headers' 'DNT, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Range, X-Auth, Accept, Origin';
+        include proxy_params;
+        proxy_pass http://unix:/var/run/yang/yang-catalog.sock ;
+        proxy_read_timeout 600s;
+    }
+
+    #
+    # YANG Regular Expression
+    #
+    location /yangre/v1 {
+        proxy_pass http://unix:/var/run/yang/yangre.sock ;
+    }
+
+    #
+    # YANGVALIDATOR
+    #
+    location /yangvalidator/v2 {
+        proxy_pass http://unix:/var/run/yang/yangvalidator.sock ;
+    }
+
+    #
+    # YANG SEARCH
+    #
+    #
+    # Redirect old URI https://www.yangcatalog.org/yang-search/module_details.php?module=yang-catalog@2018-04-03.yang
+    #
+    location = /yang-search/module_details.php {
+        if ($request_uri ~ ^/yang-search/module_details.php\?(module)=(.*).yang$) {
+            return 301 http://$host/yang-search/module_details/$2;
         }
 
-#
-# Admin GUI
-#
-         location = /admin {
-            return 301 http://$host/api/admin/login;
+        if ($request_uri ~ ^/yang-search/module_details.php\?(module)=(.*)$) {
+            return 301 http://$host/yang-search/module_details/$2;
         }
+    }
 
-        location /admin/ {
-          alias /usr/share/nginx/html/admin/;
-          try_files $uri $uri/ /index.html =404;
+    #
+    # Redirect old URI https://www.yangcatalog.org/yang-search/impact_analysis.php?modules[]=ietf-lisp@2018-11-04.yang&modules[]=ietf-lisp-mapserver@2018-06-29.yang&modules[]=ietf-lisp-address-types@2018-06-29.yang&modules[]=ietf-lisp-etr@2018-09-06.yang&modules[]=ietf-lisp-itr@2018-06-29.yang&modules[]=ietf-lisp-mapresolver@2018-06-29.yang&recurse=0&rfcs=1&show_subm=1&show_dir=both
+    #
+    location = /yang-search/impact_analysis.php {
+        if ($request_uri ~ ^\/yang-search\/impact_analysis.php\?(.*)$) {
+            return 301 http://$host/yang-search/impact_analysis/?$1;
         }
+    }
 
-#
-# API
-#
-        location /doc {
-            alias /usr/share/nginx/html/slate/build;
-        }
-
-        location = /admin/login {
-            return 301 http://$host/api/admin/login;
-        }
-
-        location /api {
-            if ($request_method = 'OPTIONS') {
-               add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS';
-            }
-            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
-            add_header 'Access-Control-Allow-Headers' 'DNT, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Range, X-Auth, Accept, Origin';
-            include proxy_params;
-            proxy_pass http://unix:/var/run/yang/yang-catalog.sock ;
-            proxy_read_timeout 600s;
-        }
-
-#
-# YANG Regular Expression
-#
-        location /yangre/v1 {
-            proxy_pass http://unix:/var/run/yang/yangre.sock ;
-        }
-
-#
-# YANGVALIDATOR
-#
-        location /yangvalidator/v2 {
-            proxy_pass http://unix:/var/run/yang/yangvalidator.sock ;
-        }
-
-#
-# YANG SEARCH
-#
-        #
-        # Redirect old URI https://www.yangcatalog.org/yang-search/module_details.php?module=yang-catalog@2018-04-03.yang
-        #
-        location = /yang-search/module_details.php {
-                if ($request_uri ~ ^/yang-search/module_details.php\?(module)=(.*).yang$) {
-                    return 301 http://$host/yang-search/module_details/$2;
-                }
-
-                if ($request_uri ~ ^/yang-search/module_details.php\?(module)=(.*)$) {
-                    return 301 http://$host/yang-search/module_details/$2;
-                }
-        }
-
-        #
-        # Redirect old URI https://www.yangcatalog.org/yang-search/impact_analysis.php?modules[]=ietf-lisp@2018-11-04.yang&modules[]=ietf-lisp-mapserver@2018-06-29.yang&modules[]=ietf-lisp-address-types@2018-06-29.yang&modules[]=ietf-lisp-etr@2018-09-06.yang&modules[]=ietf-lisp-itr@2018-06-29.yang&modules[]=ietf-lisp-mapresolver@2018-06-29.yang&recurse=0&rfcs=1&show_subm=1&show_dir=both
-        #
-        location = /yang-search/impact_analysis.php {
-                if ($request_uri ~ ^\/yang-search\/impact_analysis.php\?(.*)$) {
-                    return 301 http://$host/yang-search/impact_analysis/?$1;
-                }
-        }
-
+    #
     # redirect server error pages to the static page /50x.html
     #
     # error_page   500 502 503 504  /50x.html;
@@ -115,9 +116,9 @@ server {
     #     root   /usr/share/nginx/html;
     # }
 
-#
-# HEALTHCHECK
-#
+    #
+    # HEALTHCHECK
+    #
     location /nginx-health {
         return 200 'healthy';
     }

--- a/conf/yangcatalog-nginx-ssl.conf
+++ b/conf/yangcatalog-nginx-ssl.conf
@@ -1,8 +1,8 @@
 server {
-    server_name  yangcatalog.org www.yangcatalog.org;
+    server_name yangcatalog.org www.yangcatalog.org yangvalidator.com www.yangvalidator.com;
 
-    access_log  /var/log/nginx/access.log  ;
-    error_log  /var/log/nginx/error.log  ;
+    access_log /var/log/nginx/access.log ;
+    error_log /var/log/nginx/error.log ;
 
     charset utf-8;
 
@@ -12,102 +12,113 @@ server {
     rewrite_log on ;
 
     location / {
-        root   /usr/share/nginx/html;
+        root /usr/share/nginx/html;
         try_files $uri $uri/ /index.html =404;
-	# Allows for server side includes
-	ssi on ;
-	ssi_last_modified on ;
+        # Allows for server side includes
+        ssi on ;
+        ssi_last_modified on ;
+    }
+
+    # Redirect directly to yangvalidator tab if accessing from yangvalidator.com domain
+    location = / {
+        if ($host = yangvalidator.com) {
+            return 301 https://$host/yangvalidator ;
+        }
+
+        if ($host = www.yangvalidator.com) {
+            return 301 https://$host/yangvalidator ;
+        }
     }
 
     location /error/ {
         # Allows for server side includes
-        ssi on ;
-        ssi_last_modified on ;
-        root /usr/share/nginx/html ;
+        ssi on;
+        ssi_last_modified on;
+        root /usr/share/nginx/html;
         internal ;
     }
 
-#
-# Redirect for previously well-known URI processed by PHP
-#
-        location = /contribute.php {
-                return 301 https://$host/contribute.html ;
+    #
+    # Redirect for previously well-known URI processed by PHP
+    #
+    location = /contribute.php {
+        return 301 https://$host/contribute.html ;
+    }
+
+    #
+    # Admin GUI
+    #
+    location = /admin {
+        return 301 https://$host/api/admin/login;
+    }
+
+    location /admin/ {
+        alias /usr/share/nginx/html/admin/;
+        try_files $uri $uri/ /index.html =404;
+    }
+
+    #
+    # API
+    #
+    location /doc {
+        alias /usr/share/nginx/html/slate/build;
+    }
+
+    location = /admin/login {
+        return 301 https://$host/api/admin/login;
+    }
+
+    location /api {
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS';
+        }
+        add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+        add_header 'Access-Control-Allow-Headers' 'DNT, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Range, X-Auth, Accept, Origin';
+        include proxy_params;
+        proxy_pass http://unix:/var/run/yang/yang-catalog.sock ;
+        proxy_read_timeout 600s;
+    }
+
+    #
+    # YANG Regular Expression
+    #
+    location /yangre/v1 {
+        proxy_pass http://unix:/var/run/yang/yangre.sock ;
+    }
+
+    #
+    # YANGVALIDATOR
+    #
+    location /yangvalidator/v2 {
+        proxy_pass http://unix:/var/run/yang/yangvalidator.sock ;
+    }
+
+    #
+    # YANG SEARCH
+    #
+    #
+    # Redirect old URI https://www.yangcatalog.org/yang-search/module_details.php?module=yang-catalog@2018-04-03.yang
+    #
+    location = /yang-search/module_details.php {
+        if ($request_uri ~ ^/yang-search/module_details.php\?(module)=(.*).yang$) {
+            return 301 https://$host/yang-search/module_details/$2;
         }
 
-#
-# Admin GUI
-#
-         location = /admin {
-            return 301 https://$host/api/admin/login;
+        if ($request_uri ~ ^/yang-search/module_details.php\?(module)=(.*)$) {
+            return 301 https://$host/yang-search/module_details/$2;
         }
+    }
 
-        location /admin/ {
-          alias /usr/share/nginx/html/admin/;
-          try_files $uri $uri/ /index.html =404;
+    #
+    # Redirect old URI https://www.yangcatalog.org/yang-search/impact_analysis.php?modules[]=ietf-lisp@2018-11-04.yang&modules[]=ietf-lisp-mapserver@2018-06-29.yang&modules[]=ietf-lisp-address-types@2018-06-29.yang&modules[]=ietf-lisp-etr@2018-09-06.yang&modules[]=ietf-lisp-itr@2018-06-29.yang&modules[]=ietf-lisp-mapresolver@2018-06-29.yang&recurse=0&rfcs=1&show_subm=1&show_dir=both
+    #
+    location = /yang-search/impact_analysis.php {
+        if ($request_uri ~ ^\/yang-search\/impact_analysis.php\?(.*)$) {
+            return 301 http://$host/yang-search/impact_analysis/?$1;
         }
+    }
 
-#
-# API
-#
-        location /doc {
-            alias /usr/share/nginx/html/slate/build;
-        }
-
-        location = /admin/login {
-            return 301 https://$host/api/admin/login;
-        }
-
-        location /api {
-            if ($request_method = 'OPTIONS') {
-               add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS';
-            }
-            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
-            add_header 'Access-Control-Allow-Headers' 'DNT, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Range, X-Auth, Accept, Origin';
-            include proxy_params;
-            proxy_pass http://unix:/var/run/yang/yang-catalog.sock ;
-            proxy_read_timeout 600s;
-        }
-
-#
-# YANG Regular Expression
-#
-        location /yangre/v1 {
-            proxy_pass http://unix:/var/run/yang/yangre.sock ;
-        }
-
-#
-# YANGVALIDATOR
-#
-        location /yangvalidator/v2 {
-            proxy_pass http://unix:/var/run/yang/yangvalidator.sock ;
-        }
-
-#
-# YANG SEARCH
-#
-        #
-        # Redirect old URI https://www.yangcatalog.org/yang-search/module_details.php?module=yang-catalog@2018-04-03.yang
-        #
-        location = /yang-search/module_details.php {
-                if ($request_uri ~ ^/yang-search/module_details.php\?(module)=(.*).yang$) {
-                    return 301 https://$host/yang-search/module_details/$2;
-                }
-
-                if ($request_uri ~ ^/yang-search/module_details.php\?(module)=(.*)$) {
-                    return 301 https://$host/yang-search/module_details/$2;
-                }
-        }
-
-        #
-        # Redirect old URI https://www.yangcatalog.org/yang-search/impact_analysis.php?modules[]=ietf-lisp@2018-11-04.yang&modules[]=ietf-lisp-mapserver@2018-06-29.yang&modules[]=ietf-lisp-address-types@2018-06-29.yang&modules[]=ietf-lisp-etr@2018-09-06.yang&modules[]=ietf-lisp-itr@2018-06-29.yang&modules[]=ietf-lisp-mapresolver@2018-06-29.yang&recurse=0&rfcs=1&show_subm=1&show_dir=both
-        #
-        location = /yang-search/impact_analysis.php {
-                if ($request_uri ~ ^\/yang-search\/impact_analysis.php\?(.*)$) {
-                    return 301 http://$host/yang-search/impact_analysis/?$1;
-                }
-        }
-
-
+    #
     # redirect server error pages to the static page /50x.html
     #
     # error_page   500 502 503 504  /50x.html;
@@ -115,9 +126,9 @@ server {
     #     root   /usr/share/nginx/html;
     # }
 
-#
-# HEALTHCHECK
-#
+    #
+    # HEALTHCHECK
+    #
     location /nginx-health {
         return 200 'healthy';
     }
@@ -133,5 +144,4 @@ server {
     ssl_protocols TLSv1.3 TLSv1.2;
     ssl_prefer_server_ciphers on;
     ssl_ciphers "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:!EDH:!EXPORT";
-
 }

--- a/conf/yangcatalog-nginx.conf
+++ b/conf/yangcatalog-nginx.conf
@@ -1,17 +1,21 @@
 server {
         listen 80 default_server ;
         listen [::]:80 default_server ;
-        server_name  localhost ;
+        server_name localhost ;
 
+        # managed by Certbot
         if ($host = yangcatalog.org) {
                 return 301 https://$host$request_uri ;
-        } # managed by Certbot
+        }
         if ($host = www.yangcatalog.org) {
                 return 301 https://$host$request_uri ;
-        } # managed by Certbot
-        if ($host = yang.amsl.com) {
+        }
+        if ($host = yangvalidator.com) {
                 return 301 https://$host$request_uri ;
-        } # managed by Certbot
+        }
+        if ($host = www.yangvalidator.com) {
+                return 301 https://$host$request_uri ;
+        }
 
         # Acting as the default server, so, always go to home page
         return 301 https://$host/ ;


### PR DESCRIPTION
- NGINX config files formated
- Redirect to yangcatalog.com/yangvalidator if accessing yangcatalog.com
- Redirect to https if http used in URL

This resolves #104

Signed-off-by: Slavomir Mazur <slavomir.mazur@pantheon.tech>