### PR TITLE
Add Dockerfiles to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,6 @@
 **/node_modules
 **/dist
 **/.gitignore
+**/Dockerfile
 .env
 DOCUMENTATION


### PR DESCRIPTION
Prevents unwanted invalidation of build cache
when editing Dockerfiles.