### PR TITLE
Update pyang location

### DIFF
--- a/conf/yangcatalog.conf.sample
+++ b/conf/yangcatalog.conf.sample
@@ -188,7 +188,7 @@ modules-directory=${var}/yang/modules
 [Tool-Section]
 
 ; location of PYANG tool
-pyang-exec=/usr/bin/pyang
+pyang-exec=/usr/local/bin/pyang
 ; location of ConfD installation directory
 confd-dir=/opt/confd
 ; location of the ConfDc tool


### PR DESCRIPTION
The location of pyang inside sdo_analysis has changed
with the move to python3.9-bullseye as the base image.