### PR TITLE
feat: replaced api-receiver container with celery-worker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ services:
     depends_on:
       - confd
       - redis
+      - rabbit
 
   yangre:
     container_name: yc-yangre
@@ -89,10 +90,19 @@ services:
       retries: 5      
     restart: always
 
-  api-receiver:
-    container_name: yc-api-receiver
-    image: catalog_backend_api:latest
-    command: bash -c "chown -R yang:yang /var/run/yang; service postfix start; su yang -c 'python api/receiver.py'"
+  celery-worker:
+    container_name: yc-celery-worker
+    build:
+      context: .
+      dockerfile: ./backend/Dockerfile
+      args:
+        - YANG_ID=${YANG_ID}
+        - YANG_GID=${YANG_GID}
+        - CRON_MAIL_TO=${CRON_MAIL_TO}
+        - YANGCATALOG_CONFIG_PATH=${YANGCATALOG_CONFIG_PATH}
+    restart: always
+    user: '${YANG_ID}:${YANG_GID}'
+    command: celery -A jobs.celery:celery_app worker -l INFO
     volumes:
       - ${YANG_RESOURCES}/conf/yangcatalog.conf:/etc/yangcatalog/yangcatalog.conf:ro
       - ${YANG_RESOURCES}:/var/yang:rw
@@ -108,7 +118,10 @@ services:
       - rabbitmq
       - frontend
       - redis
-    restart: always
+    depends_on:
+      - backend
+      - rabbit
+      - redis
 
   api-recovery:
     container_name: yc-api-recovery

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,17 +92,10 @@ services:
 
   celery-worker:
     container_name: yc-celery-worker
-    build:
-      context: .
-      dockerfile: ./backend/Dockerfile
-      args:
-        - YANG_ID=${YANG_ID}
-        - YANG_GID=${YANG_GID}
-        - CRON_MAIL_TO=${CRON_MAIL_TO}
-        - YANGCATALOG_CONFIG_PATH=${YANGCATALOG_CONFIG_PATH}
+    image: catalog_backend_api:latest
     restart: always
     user: '${YANG_ID}:${YANG_GID}'
-    command: celery -A jobs.celery:celery_app worker -l INFO
+    command: bash -c "chown -R yang:yang /var/run/yang; service postfix start; celery -A jobs.celery:celery_app worker -l INFO"
     volumes:
       - ${YANG_RESOURCES}/conf/yangcatalog.conf:/etc/yangcatalog/yangcatalog.conf:ro
       - ${YANG_RESOURCES}:/var/yang:rw

--- a/k8s/templates/celery-worker/celery-worker-deployment.yaml
+++ b/k8s/templates/celery-worker/celery-worker-deployment.yaml
@@ -31,11 +31,13 @@ spec:
     spec:
       securityContext:
         fsGroup: {{ .Values.YANG_GID }}
+        runAsUser: {{ .Values.YANG_ID }}
+        runAsGroup: {{ .Values.YANG_GID }}
       containers:
       - image: localhost:32000/catalog_backend_api:latest
         name: celery-worker
         command: ["/bin/bash"]
-        args: ["-c", "chown -R yang:yang /var/run/yang; celery -A jobs.celery:celery_app worker -l INFO"]
+        args: ["-c", "chown -R yang:yang /var/run/yang; service postfix start; celery -A jobs.celery:celery_app worker -l INFO"]
         volumeMounts:
         - mountPath: /etc/yangcatalog/yangcatalog.conf
           name: yangcatalog-conf-pv

--- a/k8s/templates/celery-worker/celery-worker-deployment.yaml
+++ b/k8s/templates/celery-worker/celery-worker-deployment.yaml
@@ -5,13 +5,13 @@ metadata:
     kompose.cmd: kompose convert -c
     kompose.version: 1.21.0 (992df58d8)
   labels:
-    io.kompose.service: api-receiver
-  name: api-receiver
+    io.kompose.service: celery-worker
+  name: celery-worker
 spec:
   replicas: 1
   selector:
     matchLabels:
-      io.kompose.service: api-receiver
+      io.kompose.service: celery-worker
   strategy:
     type: Recreate
   template:
@@ -27,15 +27,15 @@ spec:
         io.kompose.network/redis: "true"
         io.kompose.network/tools-ieft-org: "true"
         io.kompose.network/rsync: "true"
-        io.kompose.service: api-receiver
+        io.kompose.service: celery-worker
     spec:
       securityContext:
         fsGroup: {{ .Values.YANG_GID }}
       containers:
       - image: localhost:32000/catalog_backend_api:latest
-        name: api-receiver
+        name: celery-worker
         command: ["/bin/bash"]
-        args: ["-c", "chown -R yang:yang /var/run/yang; service postfix start; su yang -c 'python api/receiver.py'"]
+        args: ["-c", "chown -R yang:yang /var/run/yang; celery -A jobs.celery:celery_app worker -l INFO"]
         volumeMounts:
         - mountPath: /etc/yangcatalog/yangcatalog.conf
           name: yangcatalog-conf-pv


### PR DESCRIPTION
Replaced receiver container with celery worker container in Docker and k8s configuration
**NOTE**: should be merged at the same time with this PR: https://github.com/YangCatalog/backend/pull/776