### PR TITLE
Adding helm upgrade command instead of helm install

### DIFF
--- a/k8s/templates/admin-ui/admin-ui-deployment.yaml
+++ b/k8s/templates/admin-ui/admin-ui-deployment.yaml
@@ -15,6 +15,7 @@ spec:
         kompose.cmd: kompose convert -c
         kompose.version: 1.21.0 (992df58d8)
       labels:
+        date: "{{ now | unixEpoch }}"
         io.kompose.network/frontend: "true"
         io.kompose.service: admin-ui
     spec:

--- a/k8s/templates/api-recovery/api-recovery-deployment.yaml
+++ b/k8s/templates/api-recovery/api-recovery-deployment.yaml
@@ -13,6 +13,7 @@ spec:
         kompose.cmd: kompose convert -c
         kompose.version: 1.21.0 (992df58d8)
       labels:
+        date: "{{ now | unixEpoch }}"
         io.kompose.network/backend: "true"
         io.kompose.network/confd: "true"
         io.kompose.network/redis: "true"

--- a/k8s/templates/backend/backend-deployment.yaml
+++ b/k8s/templates/backend/backend-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         kompose.cmd: kompose convert -c
         kompose.version: 1.21.0 (992df58d8)
       labels:
+        date: "{{ now | unixEpoch }}"
         io.kompose.network/backend: "true"
         io.kompose.network/confd: "true"
         io.kompose.network/frontend: "true"

--- a/k8s/templates/celery-worker/celery-worker-deployment.yaml
+++ b/k8s/templates/celery-worker/celery-worker-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         kompose.cmd: kompose convert -c
         kompose.version: 1.21.0 (992df58d8)
       labels:
+        date: "{{ now | unixEpoch }}"
         io.kompose.network/backend: "true"
         io.kompose.network/confd: "true"
         io.kompose.network/rabbitmq: "true"

--- a/k8s/templates/confd/confd-deployment.yaml
+++ b/k8s/templates/confd/confd-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         kompose.cmd: kompose convert -c
         kompose.version: 1.21.0 (992df58d8)
       labels:
+        date: "{{ now | unixEpoch }}"
         io.kompose.network/confd: "true"
         io.kompose.service: yc-confd
     spec:

--- a/k8s/templates/documentation/documentation-deployment.yaml
+++ b/k8s/templates/documentation/documentation-deployment.yaml
@@ -15,6 +15,7 @@ spec:
         kompose.cmd: kompose convert -c
         kompose.version: 1.21.0 (992df58d8)
       labels:
+        date: "{{ now | unixEpoch }}"
         io.kompose.network/frontend: "true"
         io.kompose.service: documentation
     spec:

--- a/k8s/templates/frontend/frontend-deployment.yaml
+++ b/k8s/templates/frontend/frontend-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         kompose.cmd: kompose convert -c
         kompose.version: 1.21.0 (992df58d8)
       labels:
+        date: "{{ now | unixEpoch }}"
         io.kompose.network/frontend: "true"
         io.kompose.network/elasticsearch: "true"
         io.kompose.service: yc-frontend

--- a/k8s/templates/module-compilation/module-compilation-deployment.yaml
+++ b/k8s/templates/module-compilation/module-compilation-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         kompose.cmd: kompose convert -c
         kompose.version: 1.21.0 (992df58d8)
       labels:
+        date: "{{ now | unixEpoch }}"
         io.kompose.network/confd: "true"
         io.kompose.network/frontend: "true"
         io.kompose.network/redis: "true"

--- a/k8s/templates/rabbit/rabbit-deployment.yaml
+++ b/k8s/templates/rabbit/rabbit-deployment.yaml
@@ -21,6 +21,7 @@ spec:
         kompose.cmd: kompose convert -c
         kompose.version: 1.21.0 (992df58d8)
       labels:
+        date: "{{ now | unixEpoch }}"
         io.kompose.network/rabbitmq: "true"
         io.kompose.service: yc-rabbit
     spec:

--- a/k8s/templates/redis/redis-deployment.yaml
+++ b/k8s/templates/redis/redis-deployment.yaml
@@ -18,6 +18,7 @@ spec:
         kompose.cmd: kompose convert -c
         kompose.version: 1.21.0 (992df58d8)
       labels:
+        date: "{{ now | unixEpoch }}"
         io.kompose.network/redis: "true"
         io.kompose.service: yc-redis
     spec:

--- a/k8s/templates/yangcatalog-ui/yangcatalog-ui-deployment.yaml
+++ b/k8s/templates/yangcatalog-ui/yangcatalog-ui-deployment.yaml
@@ -15,6 +15,7 @@ spec:
         kompose.cmd: kompose convert -c
         kompose.version: 1.21.0 (992df58d8)
       labels:
+        date: "{{ now | unixEpoch }}"
         io.kompose.network/frontend: "true"
         io.kompose.service: yangcatalog-ui
     spec:

--- a/k8s/templates/yangre/yangre-deployment.yaml
+++ b/k8s/templates/yangre/yangre-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         kompose.cmd: kompose convert -c
         kompose.version: 1.21.0 (992df58d8)
       labels:
+        date: "{{ now | unixEpoch }}"
         io.kompose.network/frontend: "true"
         io.kompose.network/tools-ieft-org: "true"
         io.kompose.service: yangre

--- a/k8s/templates/yangvalidator/yangvalidator-deployment.yaml
+++ b/k8s/templates/yangvalidator/yangvalidator-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         kompose.cmd: kompose convert -c
         kompose.version: 1.21.0 (992df58d8)
       labels:
+        date: "{{ now | unixEpoch }}"
         io.kompose.network/tools-ieft-org: "true"
         io.kompose.network/rsync: "true"
         io.kompose.network/frontend: "true"

--- a/kubescripts/k8s-upgrade-deploy.sh
+++ b/kubescripts/k8s-upgrade-deploy.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Pass name of the existing helm release as an argument
+microk8s helm3 upgrade -f /home/yang/deployment/k8s/values.yaml $1 /home/yang/deployment/k8s


### PR DESCRIPTION
Timestamps are added, because helm doesn't checks checksum of docker images (only tag names) and we always use 'latest' tag for our images. With our current approach to tags 'helm upgrade' would not work without this workaround. However, if we want to upgrade 1 docker image at a time, while deploying something, we should consider changing tags in deployments or alternatively, search for other workaround that will explicitly check checksums of docker image.